### PR TITLE
Upgrade to ink! v5, fix compile issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp34"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Cardinal"]
 homepage = "https://github.com/Cardinal-Cryptography/PSP34"
@@ -13,10 +13,7 @@ keywords = ["smart-contract", "token", "PSP34", "ink"]
 categories = ["cryptography::cryptocurrencies", "wasm"]
 
 [dependencies]
-ink = { version = "4.3", default-features = false }
-
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9", default-features = false, features = ["derive"], optional = true }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"
@@ -25,10 +22,7 @@ path = "lib.rs"
 default = ["std"]
 std = [
     "ink/std",
-    "scale/std",
-    "scale-info/std",
 ]
 
 enumerable = []
-contract = []
 ink-as-dependency = []

--- a/data.rs
+++ b/data.rs
@@ -11,8 +11,9 @@ use ink::storage::traits::StorageLayout;
 
 /// Type for a PSP34 token id.
 /// Contains all the possible permutations of id according to the standard.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, scale::Encode, scale::Decode)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo, StorageLayout))]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[cfg_attr(feature = "std", derive(StorageLayout))]
+#[ink::scale_derive(Encode, Decode, TypeInfo)]
 pub enum Id {
     U8(u8),
     U16(u16),

--- a/errors.rs
+++ b/errors.rs
@@ -1,7 +1,7 @@
 use ink::prelude::string::String;
 
-#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+#[derive(Debug, PartialEq, Eq)]
+#[ink::scale_derive(Encode, Decode, TypeInfo)]
 pub enum PSP34Error {
     /// Custom error type for cases if writer of traits added own restrictions
     Custom(String),

--- a/lib.rs
+++ b/lib.rs
@@ -27,7 +27,6 @@ pub use traits::PSP34Enumerable;
 // Implemented the optional PSP34Mintable (6), PSP34Burnable (7), and PSP34Metadata (8) extensions
 // and included unit tests (8).
 
-#[cfg(feature = "contract")]
 #[ink::contract]
 mod token {
     use crate::{


### PR DESCRIPTION
This PR:
- Upgrades the contract to ink! v5
- Fixes compiler issues that were previously present

